### PR TITLE
Add negotiation support for the 3.0 and 3.0.2 dialects

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -394,10 +394,10 @@ module RubySMB
         packet = packet
       end
       if [RubySMB::SMB2::Packet::SessionSetupRequest, RubySMB::SMB2::Packet::NegotiateRequest].none? {|klass| packet.is_a? klass} &&
-         @dialect == "0x0311" &&
+          ["0x0300", "0x0302", "0x0311"].include?(@dialect) &&
          @encryption_required
         begin
-          transform_request = smb3_1_encrypt(packet.to_binary_s, @session_id, @session_key, @preauth_integrity_hash_value)
+          transform_request = smb3_encrypt(packet.to_binary_s)
         rescue RubySMB::RubySMBError => e
           raise RubySMB::Error::EncryptionError, "Error while encrypting #{packet.class.name} packet (SMB 3.1.1): #{e}"
         end
@@ -409,7 +409,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet'
         end
         begin
-          raw_response = smb3_1_decrypt(transform_response, @session_key, @preauth_integrity_hash_value)
+          raw_response = smb3_decrypt(transform_response)
         rescue RubySMB::RubySMBError => e
           raise RubySMB::Error::EncryptionError, "Error while decrypting #{transform_response.class.name} packet (SMB 3.1.1): #{e}"
         end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -18,8 +18,13 @@ module RubySMB
         # This is only valid for SMB1.
         response_packet.dialects = request_packet.dialects if response_packet.respond_to? :dialects=
         version = parse_negotiate_response(response_packet)
-        if @dialect == '0x0311' && @encryption_required
-          parse_smb3_encryption_data(request_packet, response_packet)
+        if @encryption_required
+          case @dialect
+          when '0x0300', '0x0302'
+            @encryption_algorithm = RubySMB::SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITM_MAP[RubySMB::SMB2::EncryptionCapabilities::AES_128_CCM]
+          when '0x0311'
+            parse_smb3_encryption_data(request_packet, response_packet)
+          end
         end
         # If the response contains the SMB2 wildcard revision number dialect;
         # it indicates that the server implements SMB 2.1 or future dialect


### PR DESCRIPTION
This PR cleans up the `smb3*` encrypt and decrypt functions to use the instance variables to simply calling them. It also consolidates the dialect functions into one that simply generates the key appropriately. Finally it makes a few changes so if the negotiated dialect is either 0x0300 or 0x0302, the encryption / decryption will work properly.

You can test this with your `read_file_encryption.rb` script but you'll just need to manually tweak `negotiation.rb:207` to one of the older dialects. I tested all three with success and was able to read a file from the file system :tada: !