### PR TITLE
Add COMPRESSION_TRANSFORM_HEADER

### DIFF
--- a/lib/ruby_smb/smb2/packet.rb
+++ b/lib/ruby_smb/smb2/packet.rb
@@ -31,6 +31,7 @@ module RubySMB
       require 'ruby_smb/smb2/packet/ioctl_request'
       require 'ruby_smb/smb2/packet/ioctl_response'
       require 'ruby_smb/smb2/packet/transform_header'
+      require 'ruby_smb/smb2/packet/compression_transform_header'
     end
   end
 end

--- a/lib/ruby_smb/smb2/packet/compression_transform_header.rb
+++ b/lib/ruby_smb/smb2/packet/compression_transform_header.rb
@@ -1,0 +1,43 @@
+module RubySMB
+  module SMB2
+    module Packet
+      # An SMB2 COMPRESSION_TRANSFORM_HEADER Packet as defined in
+      # [2.2.42 SMB2 COMPRESSION_TRANSFORM_HEADER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/1d435f21-9a21-4f4c-828e-624a176cf2a0)
+      class CompressionTransformHeader < RubySMB::GenericPacket
+        endian :little
+
+        endian           :little
+        bit32            :protocol,                         label: 'Protocol ID Field',      initial_value: 0xFC534D42
+        uint32           :original_compressed_segment_size, label: 'Original Compressed Segment Size'
+        uint16           :compression_algorithm,            label: 'Compression Algorithm'
+        uint16           :flags,                            label: 'Flags'
+        uint32           :offset,                           label: 'Offset / Length'
+      end
+
+      # An SMB2 SMB2_COMPRESSION_TRANSFORM_HEADER_PAYLOAD Packet as defined in
+      # [2.2.42.1 SMB2_COMPRESSION_TRANSFORM_HEADER_PAYLOAD](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/8898e8e7-f1b2-47f5-a525-2ce5bad6db64)
+      class Smb2CompressionPayloadHeader < RubySMB::GenericPacket
+        endian :little
+        hide   :reserved
+
+        endian           :little
+        uint16           :algorithm_id,                     label: 'Algorithm ID'
+        uint16           :reserved
+        uint32           :length,                           label: 'Length'
+      end
+
+      # An SMB2 SMB2_COMPRESSION_PATTERN_PAYLOAD_V1 Packet as defined in
+      # [2.2.42.2 SMB2_COMPRESSION_PATTERN_PAYLOAD_V1](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/f6859837-395a-4d0a-8971-1fc3919e2d09)
+      class Smb2CompressionPatternPayloadV1 < RubySMB::GenericPacket
+        endian :little
+        hide   :reserved1, :reserved2
+
+        uint8            :pattern,                          label: 'Pattern'
+        uint8            :reserved1
+        uint16           :reserved2
+        uint32           :repetitions,                      label: 'Repetitions'
+      end
+    end
+  end
+end
+

--- a/lib/ruby_smb/smb2/packet/compression_transform_header.rb
+++ b/lib/ruby_smb/smb2/packet/compression_transform_header.rb
@@ -6,7 +6,6 @@ module RubySMB
       class CompressionTransformHeader < RubySMB::GenericPacket
         endian :little
 
-        endian           :little
         bit32            :protocol,                         label: 'Protocol ID Field',      initial_value: 0xFC534D42
         uint32           :original_compressed_segment_size, label: 'Original Compressed Segment Size'
         uint16           :compression_algorithm,            label: 'Compression Algorithm'
@@ -20,10 +19,9 @@ module RubySMB
         endian :little
         hide   :reserved
 
-        endian           :little
         uint16           :algorithm_id,                     label: 'Algorithm ID'
         uint16           :reserved
-        uint32           :length,                           label: 'Length'
+        uint32           :payload_length,                   label: 'Compressed Payload Length'
       end
 
       # An SMB2 SMB2_COMPRESSION_PATTERN_PAYLOAD_V1 Packet as defined in


### PR DESCRIPTION
This adds the three data structures defined in section 2.2.42. Since Compression can't be required, the logic isn't implemented at this time because it's not necessary for our purposes. The data structures could be useful for enumeration or exploitation of another compression-related vulnerability like SMBGhost.