### PR TITLE
Add signing support for SMB 3.x dialects

### DIFF
--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -2,6 +2,7 @@ require 'bindata'
 require 'net/ntlm'
 require 'net/ntlm/client'
 require 'openssl'
+require 'openssl/cmac'
 require 'windows_error'
 require 'windows_error/nt_status'
 # A packet parsing and manipulation library for the SMB1 and SMB2 protocols

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -388,7 +388,11 @@ module RubySMB
         packet = increment_smb_message_id(packet)
         packet.smb2_header.session_id = session_id
         unless packet.is_a?(RubySMB::SMB2::Packet::SessionSetupRequest)
-          packet = smb2_sign(packet)
+          if self.smb2
+            packet = smb2_sign(packet)
+          elsif self.smb3
+            packet = smb3_sign(packet)
+          end
         end
       else
         packet = packet

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -201,7 +201,7 @@ module RubySMB
       def smb2_authenticate
         response = smb2_ntlmssp_negotiate
         challenge_packet = smb2_ntlmssp_challenge_packet(response)
-        if @dialect == '0x0311' && (@encryption_required || @signing_required)
+        if @dialect == '0x0311'
           update_preauth_hash(challenge_packet)
         end
         @session_id = challenge_packet.smb2_header.session_id
@@ -267,7 +267,7 @@ module RubySMB
       def smb2_ntlmssp_negotiate
         packet = smb2_ntlmssp_negotiate_packet
         response = send_recv(packet)
-        if @dialect == '0x0311' && (@encryption_required || @signing_required)
+        if @dialect == '0x0311'
           update_preauth_hash(packet)
         end
         response
@@ -310,7 +310,7 @@ module RubySMB
       def smb2_ntlmssp_authenticate(type3_message, user_id)
         packet = smb2_ntlmssp_auth_packet(type3_message, user_id)
         response = send_recv(packet)
-        if @dialect == '0x0311' && (@encryption_required || @signing_required)
+        if @dialect == '0x0311'
           update_preauth_hash(packet)
         end
         response

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -201,7 +201,7 @@ module RubySMB
       def smb2_authenticate
         response = smb2_ntlmssp_negotiate
         challenge_packet = smb2_ntlmssp_challenge_packet(response)
-        if @dialect == '0x0311' && @encryption_required
+        if @dialect == '0x0311' && (@encryption_required || @signing_required)
           update_preauth_hash(challenge_packet)
         end
         @session_id = challenge_packet.smb2_header.session_id
@@ -267,7 +267,7 @@ module RubySMB
       def smb2_ntlmssp_negotiate
         packet = smb2_ntlmssp_negotiate_packet
         response = send_recv(packet)
-        if @dialect == '0x0311' && @encryption_required
+        if @dialect == '0x0311' && (@encryption_required || @signing_required)
           update_preauth_hash(packet)
         end
         response
@@ -310,7 +310,7 @@ module RubySMB
       def smb2_ntlmssp_authenticate(type3_message, user_id)
         packet = smb2_ntlmssp_auth_packet(type3_message, user_id)
         response = send_recv(packet)
-        if @dialect == '0x0311' && @encryption_required
+        if @dialect == '0x0311' && (@encryption_required || @signing_required)
           update_preauth_hash(packet)
         end
         response

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -128,7 +128,7 @@ module RubySMB
             self.smb2 = packet.dialect_revision.to_i >= 0x0200 && packet.dialect_revision.to_i < 0x0300
             self.smb3 = packet.dialect_revision.to_i >= 0x0300
           end
-          self.signing_required = packet.security_mode.signing_required == 1 if self.smb2
+          self.signing_required = packet.security_mode.signing_required == 1 if self.smb2 || self.smb3
           self.dialect = "0x%04x" % packet.dialect_revision
           self.server_max_read_size = packet.max_read_size
           self.server_max_write_size = packet.max_write_size

--- a/lib/ruby_smb/client/signing.rb
+++ b/lib/ruby_smb/client/signing.rb
@@ -42,7 +42,7 @@ module RubySMB
       end
 
       def smb3_sign(packet)
-        if packet.is_a? RubySMB::SMB2::Packet::TreeConnectRequest || (signing_required && !session_key.empty?)
+        if !session_key.empty? && (signing_required || packet.is_a?(RubySMB::SMB2::Packet::TreeConnectRequest))
           case @dialect
           when '0x0300', '0x0302'
             signing_key = RubySMB::Crypto::KDF.counter_mode(@session_key, "SMB2AESCMAC\x00", "SmbSign\x00")

--- a/lib/ruby_smb/client/signing.rb
+++ b/lib/ruby_smb/client/signing.rb
@@ -46,6 +46,8 @@ module RubySMB
           case @dialect
           when '0x0300', '0x0302'
             signing_key = RubySMB::Crypto::KDF.counter_mode(@session_key, "SMB2AESCMAC\x00", "SmbSign\x00")
+          when '0x0311'
+            signing_key = RubySMB::Crypto::KDF.counter_mode(@session_key, "SMBSigningKey\x00", @preauth_integrity_hash_value)
           else
             raise RuntimeError.new('Dialect is incompatible with SMBv3 signing')
           end

--- a/lib/ruby_smb/client/signing.rb
+++ b/lib/ruby_smb/client/signing.rb
@@ -42,7 +42,7 @@ module RubySMB
       end
 
       def smb3_sign(packet)
-        if signing_required && !session_key.empty?
+        if packet.is_a? RubySMB::SMB2::Packet::TreeConnectRequest || (signing_required && !session_key.empty?)
           case @dialect
           when '0x0300', '0x0302'
             signing_key = RubySMB::Crypto::KDF.counter_mode(@session_key, "SMB2AESCMAC\x00", "SmbSign\x00")

--- a/ruby_smb.gemspec
+++ b/ruby_smb.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubyntlm'
   spec.add_runtime_dependency 'windows_error'
   spec.add_runtime_dependency 'bindata'
+  spec.add_runtime_dependency 'openssl-cmac'
 end


### PR DESCRIPTION
This adds support for signing SMB 3.x requests, which is only necessary when encryption is disabled globally (this is not the default value).

I had to change the preauth_integrity_hash calculation logic, turns out that even with the signature requirement disabled **tree connect requests** still must be signed. It tested this with all three dialects and it checks out. See slide 13 here https://interopevents.blob.core.windows.net/events/2017/redmond/docs/1204250-SMB%203.1.1%20security%20in%20Windows%2010%20multichannel%20with%20pre-auth%20integrity.pdf for the closest thing I could find to an official reference regarding this.

I also had to add the `openssl-cmac` gem. This gets us in business immediately without having to submit upstream changes. The library is MIT licensed.

## Testing
Follow the steps in `read_file_encryption.rb` to disable encryption. Also test with signatures required and not required.

```
# Testing full encryption (encryption = true):
# On the server, run this in an elevated Powershell:
# C:\> Set-SmbServerConfiguration -EncryptData $true
#encryption = true

# Testing per-share encryption (encryption = false):
# On the server, run this in an elevated Powershell:
# C:\ Set-SmbServerConfiguration -EncryptData $false
# C:\ Set-SmbShare -Name <share name> -EncryptData 1
encryption = false
```